### PR TITLE
Add correct return type in from_orm

### DIFF
--- a/sqlmodel/main.py
+++ b/sqlmodel/main.py
@@ -521,7 +521,7 @@ class SQLModel(BaseModel, metaclass=SQLModelMetaclass, registry=default_registry
                 super().__setattr__(name, value)
 
     @classmethod
-    def from_orm(cls: Type["_Model"], obj: Any, update: Dict[str, Any] = None):
+    def from_orm(cls: Type["_Model"], obj: Any, update: Dict[str, Any] = None) -> "_Model":
         # Duplicated from Pydantic
         if not cls.__config__.orm_mode:
             raise ConfigError(


### PR DESCRIPTION
I was going to open my own PR in SQLModel to fix the return type of `from_orm`, but I see you already have some other fixes with the `_Model` typevar, so I think it makes most sense for me to piggyback on yours here. :smile: